### PR TITLE
feat: Allow to exclude dotfiles on pillar data

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,15 @@ sudo qubesctl state.apply dotfiles.copy-dom0,dotfiles.copy-sh,dotfiles.copy-vim,
 
 #### Pillar
 
-With salt, each state execution can be opt out by topic via a corresponding
-pillar set to a non true value (eg: Setting qusal:dotfiles:dom0 to false will
-disable states specific to dom0, setting qusal:dotfiles:git to false will
-disable states specific to git).
+By default, all states are executed when applied.  This can be deactivated in
+full or in part by configuring the corresponding pillar data to a non true
+value.
 
 You will need a top file and a sls file in your pillar_roots, when following
 [the Qusal's installation instructions](https://github.com/ben-grande/qusal/blob/main/docs/INSTALL.md),
 `/srv/pillar/qusal` will be added to you pillar_roots.
 
-By default, the formulas assume that you opt-in for all dotfiles.
-
-Example: /srv/pillar/qusal/dotfiles.top:
+Example: `/srv/pillar/qusal/dotfiles.top`
 
 ```yaml
 base:
@@ -82,10 +79,9 @@ base:
     - qusal.dotfiles
 ```
 
-It will apply the qusal/dotfiles sls to all targets.
+It will apply the `qusal/dotfiles.sls` on all targets.
 
-Example: /srv/pillar/qusal/dotfiles.sls containing the data to pass to the
-targets:
+Example: `/srv/pillar/qusal/dotfiles.sls`:
 
 ```yaml
 qusal:
@@ -93,7 +89,10 @@ qusal:
     dom0: false
 ```
 
-It will disable the dom0 dotfiles configuration.
+This will disable the dom0 dotfiles configuration.
+
+For a complete example of a pillar state and a listing of their corresponding
+formulas states, please refer to `pillar.sls.example`.
 
 Enable the pillar top above:
 
@@ -101,7 +100,7 @@ Enable the pillar top above:
 sudo qubesctl top.enable qusal.dotfiles pillar=true
 ```
 
-Now subsequent calls to the states of this repository will skip copy-dom0.
+Now subsequent calls to the states of this repository will skip `copy-dom0.sls`.
 
 ### Script
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!--
 SPDX-FileCopyrightText: 2023 - 2024 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
@@ -13,6 +14,7 @@ Dotfiles.
 *   [Description](#description)
 *   [Installation](#installation)
     *   [Salt](#salt)
+        *   [Pillar](#pillar)
     *   [Script](#script)
 *   [Usage](#usage)
 *   [License](#license)
@@ -58,6 +60,48 @@ Install specific files in Dom0:
 ```sh
 sudo qubesctl state.apply dotfiles.copy-dom0,dotfiles.copy-sh,dotfiles.copy-vim,dotfiles.copy-x11
 ```
+
+#### Pillar
+
+With salt, each state execution can be opt out by topic via a corresponding
+pillar set to a non true value (eg: Setting qusal:dotfiles:dom0 to false will
+disable states specific to dom0, setting qusal:dotfiles:git to false will
+disable states specific to git).
+
+You will need a top file and a sls file in your pillar_roots, when following
+[the Qusal's installation instructions](https://github.com/ben-grande/qusal/blob/main/docs/INSTALL.md),
+`/srv/pillar/qusal` will be added to you pillar_roots.
+
+By default, the formulas assume that you opt-in for all dotfiles.
+
+Example: /srv/pillar/qusal/dotfiles.top:
+
+```yaml
+base:
+  '*':
+    - qusal.dotfiles
+```
+
+It will apply the qusal/dotfiles sls to all targets.
+
+Example: /srv/pillar/qusal/dotfiles.sls containing the data to pass to the
+targets:
+
+```yaml
+qusal:
+  dotfiles:
+    dom0: false
+```
+
+It will disable the dom0 dotfiles configuration.
+
+Enable the pillar top above:
+
+```sh
+sudo qubesctl top.enable qusal.dotfiles pillar=true
+```
+
+Now subsequent calls to the states of this repository will skip copy-dom0.
 
 ### Script
 

--- a/copy-all.sls
+++ b/copy-all.sls
@@ -20,6 +20,11 @@ include:
   - .copy-x11
   - .copy-xfce
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif -%}
 
 {#

--- a/copy-all.sls
+++ b/copy-all.sls
@@ -5,7 +5,20 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if salt['pillar.get']('qusal:dotfiles:all', default=true) == true -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:dom0') == true
+         or salt['pillar.get']('qusal:dotfiles:git')  == true
+         or salt['pillar.get']('qusal:dotfiles:gtk')  == true
+         or salt['pillar.get']('qusal:dotfiles:net')  == true
+         or salt['pillar.get']('qusal:dotfiles:pgp')  == true
+         or salt['pillar.get']('qusal:dotfiles:sh')   == true
+         or salt['pillar.get']('qusal:dotfiles:ssh')  == true
+         or salt['pillar.get']('qusal:dotfiles:vim')  == true
+         or salt['pillar.get']('qusal:dotfiles:x11')  == true
+         or salt['pillar.get']('qusal:dotfiles:xfce') == true
+       )
+-%}
 
 include:
   - .copy-dom0

--- a/copy-all.sls
+++ b/copy-all.sls
@@ -1,8 +1,11 @@
 {#
 SPDX-FileCopyrightText: 2023 - 2024 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if salt['pillar.get']('qusal:dotfiles:all', default=true) == true -%}
 
 include:
   - .copy-dom0
@@ -16,6 +19,8 @@ include:
   - .copy-vim
   - .copy-x11
   - .copy-xfce
+
+{%- endif -%}
 
 {#
 Unfortunately salt.states.file does not keep permissions when using salt-ssh.

--- a/copy-dom0.sls
+++ b/copy-dom0.sls
@@ -30,4 +30,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - group: root
     - makedirs: True
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-dom0.sls
+++ b/copy-dom0.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:dom0', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:dom0') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-dom0.sls
+++ b/copy-dom0.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 - 2024 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:dom0', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -25,3 +29,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - user: root
     - group: root
     - makedirs: True
+
+{%- endif %}

--- a/copy-git.sls
+++ b/copy-git.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:git', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:git') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-git.sls
+++ b/copy-git.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:git', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -65,3 +69,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - mode: '0755'
     - recurse:
       - mode
+
+{%- endif %}

--- a/copy-git.sls
+++ b/copy-git.sls
@@ -70,4 +70,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - recurse:
       - mode
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-gtk.sls
+++ b/copy-gtk.sls
@@ -28,4 +28,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - user: root
     - group: root
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-gtk.sls
+++ b/copy-gtk.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:gtk', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -23,3 +27,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - dir_mode: '0700'
     - user: root
     - group: root
+
+{%- endif %}

--- a/copy-gtk.sls
+++ b/copy-gtk.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:gtk', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:gtk') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-mutt.sls
+++ b/copy-mutt.sls
@@ -30,4 +30,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - group: root
     - makedirs: True
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-mutt.sls
+++ b/copy-mutt.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:mutt', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:mutt') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-mutt.sls
+++ b/copy-mutt.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:mutt', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -25,3 +29,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - user: root
     - group: root
     - makedirs: True
+
+{%- endif %}

--- a/copy-net.sls
+++ b/copy-net.sls
@@ -32,4 +32,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - keep_symlinks: True
     - force_symlinks: True
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-net.sls
+++ b/copy-net.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:net', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -27,3 +31,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - group: root
     - keep_symlinks: True
     - force_symlinks: True
+
+{%- endif %}

--- a/copy-net.sls
+++ b/copy-net.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:net', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:net') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-pgp.sls
+++ b/copy-pgp.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:gpg', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -23,3 +27,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - dir_mode: '0700'
     - user: root
     - group: root
+
+{%- endif %}

--- a/copy-pgp.sls
+++ b/copy-pgp.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:gpg', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:pgp') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-pgp.sls
+++ b/copy-pgp.sls
@@ -28,4 +28,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - user: root
     - group: root
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-sh.sls
+++ b/copy-sh.sls
@@ -48,4 +48,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - recurse:
       - mode
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-sh.sls
+++ b/copy-sh.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:sh', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -43,3 +47,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - dir_mode: '0755'
     - recurse:
       - mode
+
+{%- endif %}

--- a/copy-sh.sls
+++ b/copy-sh.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:sh', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:sh') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-ssh.sls
+++ b/copy-ssh.sls
@@ -29,4 +29,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - user: root
     - group: root
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-ssh.sls
+++ b/copy-ssh.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:ssh', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -24,3 +28,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - dir_mode: '0700'
     - user: root
     - group: root
+
+{%- endif %}

--- a/copy-ssh.sls
+++ b/copy-ssh.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:ssh', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:ssh') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-tmux.sls
+++ b/copy-tmux.sls
@@ -42,4 +42,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - recurse:
       - mode
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-tmux.sls
+++ b/copy-tmux.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:tmux', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -37,3 +41,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - mode: '0755'
     - recurse:
       - mode
+
+{%- endif %}

--- a/copy-tmux.sls
+++ b/copy-tmux.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:tmux', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:tmux') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-vim.sls
+++ b/copy-vim.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:vim', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:vim') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-vim.sls
+++ b/copy-vim.sls
@@ -28,4 +28,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - user: root
     - group: root
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-vim.sls
+++ b/copy-vim.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:vim', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -23,3 +27,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - dir_mode: '0700'
     - user: root
     - group: root
+
+{%- endif %}

--- a/copy-x11.sls
+++ b/copy-x11.sls
@@ -32,4 +32,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - keep_symlinks: True
     - force_symlinks: True
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-x11.sls
+++ b/copy-x11.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2023 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:x11', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -27,3 +31,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - group: root
     - keep_symlinks: True
     - force_symlinks: True
+
+{%- endif %}

--- a/copy-x11.sls
+++ b/copy-x11.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:x11', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:x11') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-xfce.sls
+++ b/copy-xfce.sls
@@ -32,4 +32,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - keep_symlinks: True
     - force_symlinks: True
 
+{%- else -%}
+
+"{{ sls }}-is-deactivated":
+  test.nop
+
 {%- endif %}

--- a/copy-xfce.sls
+++ b/copy-xfce.sls
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
-     and (salt['pillar.get']('qusal:dotfiles:xfce', default=true) == true )) -%}
+{%- if (
+         salt['pillar.get']('qusal:dotfiles:all', default=true) == true
+         or salt['pillar.get']('qusal:dotfiles:xfce') == true
+       )
+-%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 

--- a/copy-xfce.sls
+++ b/copy-xfce.sls
@@ -1,8 +1,12 @@
 {#
 SPDX-FileCopyrightText: 2024 Benjamin Grande M. S. <ben.grande.b@gmail.com>
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
+
+{%- if ( (salt['pillar.get']('qusal:dotfiles:all', default=true) == true )
+     and (salt['pillar.get']('qusal:dotfiles:xfce', default=true) == true )) -%}
 
 {%- import "dom0/gui-user.jinja" as gui_user -%}
 
@@ -27,3 +31,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     - group: root
     - keep_symlinks: True
     - force_symlinks: True
+
+{%- endif %}

--- a/pillar.sls.example
+++ b/pillar.sls.example
@@ -12,37 +12,28 @@ extension and referenced by a top file. See 'pillar.top.example' for an example
 and the README for instructions.
 
 Each entry in the pillar state is optional. You can disable the entire dotfile
-setup by keeping only 'qusal:dotfiles:all' to 'false', or selectively disable
-individual components by setting 'false' for the corresponding state entries.
+setup by keeping *only* 'qusal:dotfiles:all' to 'false', or selectively
+disabling individual components by setting 'false' for the corresponding state
+entries (eg: 'dom0' correspond to 'copy-dom0.sls').
+
+Alternatively you can keep 'qusal:dotfiles:all' to 'true' and selectively
+enabling individual components by setting 'true' for the corresponding state
+entries.
 
 #}
 
 qusal:
   dotfiles:
-    # Control whether or not applying the copy-all.sls or any other dotfiles states.
-    # Disabling it will disable all states, unless some are specifically whitelisted.
     all: true
-    # Control whether or not applying the copy-x11.sls state.
     dom0: true
-    # Control whether or not applying the copy-dom0.sls state.
     git: true
-    # Control whether or not applying the copy-git.sls state.
     gtk: true
-    # Control whether or not applying the copy-gtk.sls state.
     mutt: true
-    # Control whether or not applying the copy-mutt.sls state.
     net: true
-    # Control whether or not applying the copy-net.sls state.
     pgp: true
-    # Control whether or not applying the copy-pgp.sls state.
     sh: true
-    # Control whether or not applying the copy-sh.sls state.
     ssh: true
-    # Control whether or not applying the copy-ssh.sls state.
     tmux: true
-    # Control whether or not applying the copy-tmux.sls state.
     vim: true
-    # Control whether or not applying the copy-vim.sls state.
     x11: true
-    # Control whether or not applying the copy-x11.sls state.
     xfce: true

--- a/pillar.sls.example
+++ b/pillar.sls.example
@@ -1,0 +1,48 @@
+{#
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+#}
+{#
+
+Example of a pillar state structure for https://github.com/ben-grande/dotfiles
+
+This file need to be placed in your pillar_roots, renamed with a '.sls'
+extension and referenced by a top file. See 'pillar.top.example' for an example
+and the README for instructions.
+
+Each entry in the pillar state is optional. You can disable the entire dotfile
+setup by keeping only 'qusal:dotfiles:all' to 'false', or selectively disable
+individual components by setting 'false' for the corresponding state entries.
+
+#}
+
+qusal:
+  dotfiles:
+    # Control whether or not applying the copy-all.sls or any other dotfiles states.
+    # Disabling it will disable all states, unless some are specifically whitelisted.
+    all: true
+    # Control whether or not applying the copy-x11.sls state.
+    dom0: true
+    # Control whether or not applying the copy-dom0.sls state.
+    git: true
+    # Control whether or not applying the copy-git.sls state.
+    gtk: true
+    # Control whether or not applying the copy-gtk.sls state.
+    mutt: true
+    # Control whether or not applying the copy-mutt.sls state.
+    net: true
+    # Control whether or not applying the copy-net.sls state.
+    pgp: true
+    # Control whether or not applying the copy-pgp.sls state.
+    sh: true
+    # Control whether or not applying the copy-sh.sls state.
+    ssh: true
+    # Control whether or not applying the copy-ssh.sls state.
+    tmux: true
+    # Control whether or not applying the copy-tmux.sls state.
+    vim: true
+    # Control whether or not applying the copy-vim.sls state.
+    x11: true
+    # Control whether or not applying the copy-x11.sls state.
+    xfce: true

--- a/pillar.top.example
+++ b/pillar.top.example
@@ -7,8 +7,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Example of a pillar top structure for https://github.com/ben-grande/dotfiles
 
-This file need to be placed in your pillar_roots, renamed with a '.top'
-extension, to refer to a valid pillar state file and enabled with 'qubectl
+This file needs to be placed in your pillar_roots, renamed with a '.top'
+extension, to refer to a valid pillar state file and enabled with 'qubesctl
 top.enable'. See 'pillar.sls.example' for an example and the README for
 instructions.
 

--- a/pillar.top.example
+++ b/pillar.top.example
@@ -1,0 +1,19 @@
+{#
+SPDX-FileCopyrightText: 2024 seven-beep <ebn@entreparentheses.xyz>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+#}
+{#
+
+Example of a pillar top structure for https://github.com/ben-grande/dotfiles
+
+This file need to be placed in your pillar_roots, renamed with a '.top'
+extension, to refer to a valid pillar state file and enabled with 'qubectl
+top.enable'. See 'pillar.sls.example' for an example and the README for
+instructions.
+
+#}
+
+base:
+  '*':
+    - qusal.dotfiles


### PR DESCRIPTION
Hello, 

Following https://github.com/ben-grande/qusal/issues/74, here is a draft for allowing to opt-out the dotfiles states on a pillar basis.

After reflection, I do not think it is necessary to create and propagate a pillar.top and pillar.sls on this repository : the states are automatically applied with default values. 

 A few thinking about pillars :

 - Too many pillar resolution has been known to cause performances penalities https://saidvandeklundert.net/2019-11-18-saltstack-pillar-data-and-map-files/ (however we have a good marge before hitting 100.000 lines!)
 - Implementing theses new files will means to rework the setup scripts and the rpm specs.
 - The placement of theses files need to be thinked about. Right now the file hierachy put all formulas into qusal/salt, however there is a strict distinction between file_roots and pillar_roots as both files inside are top files and sls files.

As you mentioned you worried about qusal states that may not work without the dotfiles ones, I will try to help to identify / fix them in the following days.